### PR TITLE
docs(references): daily intelligence update 2026-04-15 (run 2)

### DIFF
--- a/.claude/skills/gh-aw-report/knowledge-base.md
+++ b/.claude/skills/gh-aw-report/knowledge-base.md
@@ -49,7 +49,7 @@
 - **Modes**: Plan mode (shows plan first), Autopilot mode (fully autonomous)
 - **Background delegation**: prefix prompt with `&` to send to cloud coding agent
 - **Sub-agents**: Explore (codebase analysis), Task (build/test), Code Review, Plan
-- **Models**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, Gemini 3 Pro
+- **Models**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, ~~Gemini 3 Pro~~ [SUPERSEDED by 2026-04-15 — deprecated 2026-03-26]
 - **January 2026 changelog**: Enhanced agents, context management, new install methods
 
 ### GitHub Copilot Workspace / Agent Mode (as of 2026-04-14)
@@ -83,6 +83,26 @@
 - AWF (Agent Workflow Firewall) restricts network egress
 - Safe Outputs subsystem handles write operations in separate permission-controlled jobs
 - Threat detection job runs per-workflow: prompt injection, credential leaks, malicious code
+
+## [2026-04-15] Daily Intelligence Update
+
+### 2026-04-15 -- version -- gh-aw CLI v0.68.3
+Released 2026-04-14. Model-not-supported detection, shared import `checkout`/`env` fields, TBT metric, OTEL token breakdowns, 5 push_signed_commits.cjs fixes.
+
+### 2026-04-15 -- version -- GitHub MCP Server v0.33.0/v0.33.1
+Released 2026-04-14. Granular PRs/issues toolsets, resolve review threads tool, `list_commits` `path`/`since`/`until` params, configurable server name.
+
+### 2026-04-15 -- deprecation -- Gemini 3 Pro deprecated
+Deprecated 2026-03-26 across all GitHub Copilot experiences. Use Gemini 3 Ultra.
+
+### 2026-04-15 -- feature -- Agent HQ and model selection
+Agent HQ: multi-vendor agents on GitHub. Model selection for Claude/Codex on github.com (2026-04-14).
+
+### 2026-04-15 -- feature -- Copilot data residency + FedRAMP
+US/EU data residency (2026-04-13). FedRAMP Moderate for US gov. `copilot --remote` public preview.
+
+### 2026-04-15 -- ecosystem -- GitHub Actions April changes
+Workflow reruns capped at 50 (2026-04-10). OIDC for Dependabot/code scanning. Code scanning→Issues linking. Async SBOM exports.
 
 ---
 <!-- Append new entries above this line, newest first -->

--- a/.claude/skills/gh-aw-report/references/gh-aw-architecture.md
+++ b/.claude/skills/gh-aw-report/references/gh-aw-architecture.md
@@ -22,7 +22,7 @@ that traditional deterministic CI cannot handle.
   the agent — they are NOT managed by the CLI
 - Two-file structure: a `.md` source and a `.lock.yml` compiled output
 
-## gh aw CLI
+## gh aw CLI (v0.68.3 as of 2026-04-14)
 
 - Default AI agent: GitHub Copilot CLI
 - Supported alternative agents: Claude (Anthropic), Codex (OpenAI), custom agents
@@ -72,6 +72,8 @@ that traditional deterministic CI cannot handle.
 - Enterprise: HTTP mode with per-request OAuth token forwarding
 - Insiders mode: opt-in experimental features via `/insiders` URL or config header
 - Projects toolset: consolidated (reduces ~23,000 tokens/50% token usage)
+- **v0.33.0 (2026-04-14):** Granular PRs/issues toolsets, resolve review threads tool, `list_commits` gets `path`/`since`/`until` params
+- **v0.33.1 (2026-04-14):** Hotfix release
 
 ## GitHub Copilot CLI (GA: February 25, 2026)
 
@@ -80,7 +82,7 @@ that traditional deterministic CI cannot handle.
 - **Plan mode**: shows plan before executing
 - **Background delegation**: prefix with `&` to delegate to cloud coding agent
 - **Specialized sub-agents**: Explore, Task, Code Review, Plan
-- **Model support**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, Gemini 3 Pro
+- **Model support**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, ~~Gemini 3 Pro~~ (deprecated 2026-03-26; use Gemini 3 Ultra)
 - Available to all paid Copilot subscribers (Pro, Business, Enterprise)
 
 ## GitHub Copilot Workspace / Agent Mode

--- a/.claude/skills/gh-aw-report/references/gh-aw-architecture.md
+++ b/.claude/skills/gh-aw-report/references/gh-aw-architecture.md
@@ -22,8 +22,9 @@ that traditional deterministic CI cannot handle.
   the agent — they are NOT managed by the CLI
 - Two-file structure: a `.md` source and a `.lock.yml` compiled output
 
-## gh aw CLI (v0.68.3 as of 2026-04-14)
+## gh aw CLI
 
+- Version referenced: `v0.68.3` (as of 2026-04-14)
 - Default AI agent: GitHub Copilot CLI
 - Supported alternative agents: Claude (Anthropic), Codex (OpenAI), custom agents
 - Key commands:
@@ -72,7 +73,7 @@ that traditional deterministic CI cannot handle.
 - Enterprise: HTTP mode with per-request OAuth token forwarding
 - Insiders mode: opt-in experimental features via `/insiders` URL or config header
 - Projects toolset: consolidated (reduces ~23,000 tokens/50% token usage)
-- **v0.33.0 (2026-04-14):** Granular PRs/issues toolsets, resolve review threads tool, `list_commits` gets `path`/`since`/`until` params
+- **v0.33.0 (2026-04-14):** Granular PRs/issues toolsets, resolve review threads tool, `list_commits` gets `path`/`since`/`until` params, configurable server name/title via translation strings, OSS HTTP logging adapter, static CLI flags as per-request filter upper bound
 - **v0.33.1 (2026-04-14):** Hotfix release
 
 ## GitHub Copilot CLI (GA: February 25, 2026)
@@ -82,7 +83,7 @@ that traditional deterministic CI cannot handle.
 - **Plan mode**: shows plan before executing
 - **Background delegation**: prefix with `&` to delegate to cloud coding agent
 - **Specialized sub-agents**: Explore, Task, Code Review, Plan
-- **Model support**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, ~~Gemini 3 Pro~~ (deprecated 2026-03-26; use Gemini 3 Ultra)
+- **Model support**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, ~~Gemini 3 Pro~~ (deprecated 2026-03-26)
 - Available to all paid Copilot subscribers (Pro, Business, Enterprise)
 
 ## GitHub Copilot Workspace / Agent Mode

--- a/skills/aw-author/references/orchestration.md
+++ b/skills/aw-author/references/orchestration.md
@@ -294,7 +294,7 @@ When specifying `engine.model`, the following values are available as of Copilot
 | `copilot` | `claude-opus` | Claude Opus 4.6 — highest reasoning capability |
 | `copilot` | `claude-sonnet` | Claude Sonnet 4.6 — balanced speed/capability |
 | `copilot` | `gpt-5-codex` | GPT-5.3-Codex — code-optimized |
-| `copilot` | `gemini-pro` | Gemini 3 Pro — multimodal |
+| `copilot` | `gemini-pro` | ~~Gemini 3 Pro~~ **DEPRECATED 2026-03-26** — use `gemini-ultra` (Gemini 3 Ultra) |
 | `claude` | *(default)* | Claude Sonnet 4.6 via direct Anthropic API |
 
 For reasoning-heavy patterns (security review, complex triage), prefer `claude-opus` or enable `thinking: true` with the `claude` engine.

--- a/skills/aw-author/references/orchestration.md
+++ b/skills/aw-author/references/orchestration.md
@@ -294,7 +294,7 @@ When specifying `engine.model`, the following values are available as of Copilot
 | `copilot` | `claude-opus` | Claude Opus 4.6 — highest reasoning capability |
 | `copilot` | `claude-sonnet` | Claude Sonnet 4.6 — balanced speed/capability |
 | `copilot` | `gpt-5-codex` | GPT-5.3-Codex — code-optimized |
-| `copilot` | `gemini-pro` | ~~Gemini 3 Pro~~ **DEPRECATED 2026-03-26** — use `gemini-ultra` (Gemini 3 Ultra) |
+| `copilot` | `gemini-pro` | ~~Gemini 3 Pro~~ **DEPRECATED 2026-03-26** — migrate to a documented supported model such as `claude-sonnet` or `claude-opus`, depending on capability needs |
 | `claude` | *(default)* | Claude Sonnet 4.6 via direct Anthropic API |
 
 For reasoning-heavy patterns (security review, complex triage), prefer `claude-opus` or enable `thinking: true` with the `claude` engine.

--- a/skills/gh-aw-report/knowledge-base.md
+++ b/skills/gh-aw-report/knowledge-base.md
@@ -49,7 +49,7 @@
 - **Modes**: Plan mode (shows plan first), Autopilot mode (fully autonomous)
 - **Background delegation**: prefix prompt with `&` to send to cloud coding agent
 - **Sub-agents**: Explore (codebase analysis), Task (build/test), Code Review, Plan
-- **Models**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, Gemini 3 Pro
+- **Models**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, ~~Gemini 3 Pro~~ [SUPERSEDED by 2026-04-15 — deprecated 2026-03-26]
 - **January 2026 changelog**: Enhanced agents, context management, new install methods
 
 ### GitHub Copilot Workspace / Agent Mode (as of 2026-04-14)
@@ -83,6 +83,26 @@
 - AWF (Agent Workflow Firewall) restricts network egress
 - Safe Outputs subsystem handles write operations in separate permission-controlled jobs
 - Threat detection job runs per-workflow: prompt injection, credential leaks, malicious code
+
+## [2026-04-15] Daily Intelligence Update
+
+### 2026-04-15 -- version -- gh-aw CLI v0.68.3
+Released 2026-04-14. Model-not-supported detection, shared import `checkout`/`env` fields, TBT metric, OTEL token breakdowns, 5 push_signed_commits.cjs fixes.
+
+### 2026-04-15 -- version -- GitHub MCP Server v0.33.0/v0.33.1
+Released 2026-04-14. Granular PRs/issues toolsets, resolve review threads tool, `list_commits` `path`/`since`/`until` params, configurable server name.
+
+### 2026-04-15 -- deprecation -- Gemini 3 Pro deprecated
+Deprecated 2026-03-26 across all GitHub Copilot experiences. Use Gemini 3 Ultra.
+
+### 2026-04-15 -- feature -- Agent HQ and model selection
+Agent HQ: multi-vendor agents on GitHub. Model selection for Claude/Codex on github.com (2026-04-14).
+
+### 2026-04-15 -- feature -- Copilot data residency + FedRAMP
+US/EU data residency (2026-04-13). FedRAMP Moderate for US gov. `copilot --remote` public preview.
+
+### 2026-04-15 -- ecosystem -- GitHub Actions April changes
+Workflow reruns capped at 50 (2026-04-10). OIDC for Dependabot/code scanning. Code scanning→Issues linking. Async SBOM exports.
 
 ---
 <!-- Append new entries above this line, newest first -->

--- a/skills/gh-aw-report/references/gh-aw-architecture.md
+++ b/skills/gh-aw-report/references/gh-aw-architecture.md
@@ -63,7 +63,7 @@ Stable architectural facts about the GitHub Agentic Workflows ecosystem. Used by
 - **Plan mode:** Displays step-by-step plan before execution for review
 - **Background delegation:** Prefix prompt with `&` to delegate to cloud coding agent
 - **Specialized sub-agents:** Explore, Task, Code Review, Plan
-- **Model support:** Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, Gemini 3 Pro
+- **Model support:** Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, ~~Gemini 3 Pro~~ (deprecated 2026-03-26)
 - Available to all paid Copilot subscribers (Pro, Business, Enterprise)
 
 ### GitHub Models API
@@ -80,6 +80,8 @@ Stable architectural facts about the GitHub Agentic Workflows ecosystem. Used by
 - **`base_ref` parameter:** On Copilot PR tools for stacked PR / feature branch workflows
 - **Insiders mode:** Opt-in experimental features via `/insiders` URL or config header
 - **HTTP mode:** Enterprise deployment with per-request OAuth token forwarding
+- **v0.33.0 (2026-04-14):** Granular PRs/issues toolsets, resolve review threads tool, `list_commits` gets `path`/`since`/`until` params, configurable server name/title via translation strings, OSS HTTP logging adapter, static CLI flags as per-request filter upper bound
+- **v0.33.1 (2026-04-14):** Hotfix release
 - **MCP Gateway:** Centralized access management for MCP servers (v0.1.9 as of 2026-04-14)
 
 ### Claude Code


### PR DESCRIPTION
## Summary

Automated reference file updates from daily intelligence sweep (force re-run).

## Gaps Addressed

- **GAP-001** (incorrect): Gemini 3 Pro listed without deprecation notice in orchestration.md — Closes #18
- **GAP-002** (incorrect): Gemini 3 Pro listed without deprecation notice in gh-aw-architecture.md — Closes #19
- **GAP-003** (outdated): GitHub MCP Server v0.33.0/v0.33.1 features missing from architecture — Closes #10
- **GAP-004** (outdated): gh-aw CLI version (v0.68.3) missing from architecture — Closes #11
- **KB update**: 6 new knowledge base entries covering versions, deprecations, features, ecosystem

## Intelligence Report

https://github.com/zircote/github-agentic-workflows/discussions/8

## Changes

```
 .claude/skills/gh-aw-report/knowledge-base.md              | 22 +++++++++++++++++++-
 .claude/skills/gh-aw-report/references/gh-aw-architecture.md |  6 ++++--
 skills/aw-author/references/orchestration.md                 |  2 +-
 3 files changed, 26 insertions(+), 4 deletions(-)
```

---
_Automated by /aw-daily --force_