### PR TITLE
docs(references): daily intelligence update 2026-04-16

### DIFF
--- a/.claude/skills/gh-aw-report/knowledge-base.md
+++ b/.claude/skills/gh-aw-report/knowledge-base.md
@@ -108,29 +108,29 @@ Workflow reruns capped at 50 (2026-04-10). OIDC for Dependabot/code scanning. Co
 
 ## [2026-04-16] Daily Intelligence Update
 
-### gh-aw CLI v0.68.3 — New Frontmatter Fields
+### 2026-04-16 -- feature -- gh-aw v0.68.3 New Frontmatter Fields
 - **`pre-steps:`** — Runs custom steps at job start, **before checkout**. Use for token minting or pre-checkout setup. Outputs accessible via `${{ steps.<id>.outputs.<name> }}` for use in `checkout.github-token` to avoid masked-value cross-job boundary issues. Same security restrictions as `steps:`.
 - **`run-install-scripts:`** — Boolean (default: `false`). Allows npm pre/post install scripts. Default adds `--ignore-scripts` to all npm install commands (supply chain protection). Setting `true` disables globally; per-runtime scope via `runtimes.node.run-install-scripts`. Compile-time warning (strict mode: error).
 - **`on.stale-check:`** — Boolean nested under `on:`, default `true`. When `false`, disables the frontmatter hash check in the activation job. Required for cross-repo org ruleset deployments.
-- Source: PR #26607 in github/gh-aw ("Sync github-agentic-workflows.md with v0.68.3", expires 2026-04-18)
+- Source: PR #26607 in github/gh-aw ("Sync github-agentic-workflows.md with v0.68.3")
 
-### gh-aw Security Fixes (active PRs 2026-04-16)
+### 2026-04-16 -- security -- gh-aw Security Fixes
 - **Steganographic injection**: PR #26596 strips markdown link title text to close injection channel
 - **XPIA @mentions**: PR #26589 sanitizes @mentions in `create_issue` body
 - **cache-memory sanitization**: PR #26587 adds pre-agent working-tree sanitization (neutralizes planted executables/disallowed files)
 - **Lock file integrity schema v4**: PR #26594 extends integrity check to detect post-compilation YAML tampering
 
-### GitHub MCP Server (as of 2026-04-16)
+### 2026-04-16 -- version -- GitHub MCP Server v0.33.0/v0.33.1
 - **v0.33.0** (2026-04-14): Granular PRs/issues toolsets, `resolve_review_thread` tool, `list_commits` path/since/until params, configurable server name/title via translation strings, OSS HTTP logging adapter
 - **v0.33.1** (2026-04-14): Hotfix release
 
-### Claude Code (as of 2026-04-16)
+### 2026-04-16 -- feature -- Claude Code Remote Tasks
 - **Remote Tasks** (launched March 20, 2026): Define GitHub repo + prompt + schedule → Claude runs autonomously on Anthropic cloud infrastructure. Supports cron scheduling.
 - **Remote Sessions**: Start task, close laptop, session continues on Anthropic infrastructure
 - **Open-sourced**: Agent layer at `anthropics/claude-code`
 - **v2.1.76** (March 14, 2026): Enhanced MCP elicitation support, improved tool discovery
 
-### GitHub Copilot (as of 2026-04-16)
+### 2026-04-16 -- feature -- Copilot Cloud Agent Per-Org Control
 - **Copilot cloud agent per-org control** (April 15, 2026): Can now be enabled for selected organizations via AI Controls page → "Agent" → "Copilot Cloud Agent"
 - **REST API version 2026-03-10**: Available with breaking changes to the REST API
 

--- a/.claude/skills/gh-aw-report/knowledge-base.md
+++ b/.claude/skills/gh-aw-report/knowledge-base.md
@@ -105,4 +105,34 @@ US/EU data residency (2026-04-13). FedRAMP Moderate for US gov. `copilot --remot
 Workflow reruns capped at 50 (2026-04-10). OIDC for Dependabot/code scanning. Code scanning→Issues linking. Async SBOM exports.
 
 ---
+
+## [2026-04-16] Daily Intelligence Update
+
+### gh-aw CLI v0.68.3 — New Frontmatter Fields
+- **`pre-steps:`** — Runs custom steps at job start, **before checkout**. Use for token minting or pre-checkout setup. Outputs accessible via `${{ steps.<id>.outputs.<name> }}` for use in `checkout.github-token` to avoid masked-value cross-job boundary issues. Same security restrictions as `steps:`.
+- **`run-install-scripts:`** — Boolean (default: `false`). Allows npm pre/post install scripts. Default adds `--ignore-scripts` to all npm install commands (supply chain protection). Setting `true` disables globally; per-runtime scope via `runtimes.node.run-install-scripts`. Compile-time warning (strict mode: error).
+- **`on.stale-check:`** — Boolean nested under `on:`, default `true`. When `false`, disables the frontmatter hash check in the activation job. Required for cross-repo org ruleset deployments.
+- Source: PR #26607 in github/gh-aw ("Sync github-agentic-workflows.md with v0.68.3", expires 2026-04-18)
+
+### gh-aw Security Fixes (active PRs 2026-04-16)
+- **Steganographic injection**: PR #26596 strips markdown link title text to close injection channel
+- **XPIA @mentions**: PR #26589 sanitizes @mentions in `create_issue` body
+- **cache-memory sanitization**: PR #26587 adds pre-agent working-tree sanitization (neutralizes planted executables/disallowed files)
+- **Lock file integrity schema v4**: PR #26594 extends integrity check to detect post-compilation YAML tampering
+
+### GitHub MCP Server (as of 2026-04-16)
+- **v0.33.0** (2026-04-14): Granular PRs/issues toolsets, `resolve_review_thread` tool, `list_commits` path/since/until params, configurable server name/title via translation strings, OSS HTTP logging adapter
+- **v0.33.1** (2026-04-14): Hotfix release
+
+### Claude Code (as of 2026-04-16)
+- **Remote Tasks** (launched March 20, 2026): Define GitHub repo + prompt + schedule → Claude runs autonomously on Anthropic cloud infrastructure. Supports cron scheduling.
+- **Remote Sessions**: Start task, close laptop, session continues on Anthropic infrastructure
+- **Open-sourced**: Agent layer at `anthropics/claude-code`
+- **v2.1.76** (March 14, 2026): Enhanced MCP elicitation support, improved tool discovery
+
+### GitHub Copilot (as of 2026-04-16)
+- **Copilot cloud agent per-org control** (April 15, 2026): Can now be enabled for selected organizations via AI Controls page → "Agent" → "Copilot Cloud Agent"
+- **REST API version 2026-03-10**: Available with breaking changes to the REST API
+
+---
 <!-- Append new entries above this line, newest first -->

--- a/.claude/skills/gh-aw-report/references/gh-aw-architecture.md
+++ b/.claude/skills/gh-aw-report/references/gh-aw-architecture.md
@@ -1,6 +1,6 @@
 # gh-aw Architecture Reference
 
-> Last updated: 2026-04-14. This file captures stable architectural facts about the
+> Last updated: 2026-04-16. This file captures stable architectural facts about the
 > GitHub Agentic Workflows system to reduce web searches on known-stable information.
 
 ## System Overview
@@ -94,6 +94,15 @@ that traditional deterministic CI cannot handle.
   fix PR via coding agent automatically
 - Assign GitHub issue to Copilot → autonomous background work → PR opened for review
 - Waitlist removed for Pro/Business/Enterprise (early 2026)
+
+## Claude Code (Anthropic)
+
+- Anthropic's CLI agentic coding tool, integrates with GitHub via MCP servers
+- Can serve as the AI engine in gh-aw workflows (alternative to Copilot CLI)
+- **Open-sourced** (2026): Agent layer at `anthropics/claude-code`
+- **Remote Tasks** (launched March 20, 2026): Define a GitHub repo + prompt + cron schedule → Claude runs autonomously on Anthropic's cloud infrastructure; cron scheduling supported
+- **Remote Sessions**: Start a task locally, close laptop; session continues on Anthropic infrastructure
+- Directly comparable to gh-aw scheduled workflows for Claude-engine use cases — a native Anthropic alternative that does not require GitHub Actions
 
 ## Continuous AI Paradigm
 

--- a/skills/aw-author/references/frontmatter-schema.md
+++ b/skills/aw-author/references/frontmatter-schema.md
@@ -56,12 +56,14 @@ gh-aw workflow files use YAML frontmatter delimited by `---` markers. This is th
 | `playwright` | [Tools](#5-tools-tools) | [link](#playwright-tool) |
 | `plugins` | [Imports & Dependencies](#10-imports--dependencies) | [link](#plugins) *(deprecated)* |
 | `post-steps` | [Steps & Post-Steps](#8-steps--post-steps) | [link](#post-steps) |
+| `pre-steps` | [Steps & Post-Steps](#8-steps--post-steps) | [link](#pre-steps) |
 | `push-to-pull-request-branch` | [Safe Outputs](#7-safe-outputs-safe-outputs) | [link](#push-to-pull-request-branch) |
 | `reaction` | [Triggers](#2-triggers-on) | [link](#reaction) |
 | `remove-labels` | [Safe Outputs](#7-safe-outputs-safe-outputs) | [link](#remove-labels) |
 | `repo-memory` | [Tools](#5-tools-tools) | [link](#repo-memory-tool) |
 | `reply-to-pull-request-review-comment` | [Safe Outputs](#7-safe-outputs-safe-outputs) | [link](#reply-to-pull-request-review-comment) |
 | `resolve-pull-request-review-thread` | [Safe Outputs](#7-safe-outputs-safe-outputs) | [link](#resolve-pull-request-review-thread) |
+| `run-install-scripts` | [Engine Configuration](#4-engine-configuration-engine) | [link](#run-install-scripts) |
 | `run-name` | [Engine Configuration](#4-engine-configuration-engine) | [link](#run-name) |
 | `runs-on` | [Engine Configuration](#4-engine-configuration-engine) | [link](#runs-on) |
 | `safe-outputs` | [Safe Outputs](#7-safe-outputs-safe-outputs) | [link](#safe-outputs-root) |
@@ -71,6 +73,7 @@ gh-aw workflow files use YAML frontmatter delimited by `---` markers. This is th
 | `services` | [Container & Services](#11-container--services) | [link](#services) |
 | `skip-if-match` | [Triggers](#2-triggers-on) | [link](#skip-if-match) |
 | `skip-if-no-match` | [Triggers](#2-triggers-on) | [link](#skip-if-no-match) |
+| `stale-check` | [Triggers](#2-triggers-on) | [link](#stale-check) |
 | `source` | [Workflow Identity](#1-workflow-identity) | [link](#source) |
 | `startup-timeout` | [Tools](#5-tools-tools) | [link](#startup-timeout) |
 | `steps` | [Steps & Post-Steps](#8-steps--post-steps) | [link](#steps) |
@@ -497,6 +500,22 @@ if: github.event.action == 'labeled' && contains(github.event.issue.labels.*.nam
 - **Gotchas:** Uses GitHub Actions expression syntax without the `${{ }}` wrapper.
 - **Cross-references:** `production-gotchas.md` — `if` guard
 
+#### `stale-check` {#stale-check}
+
+- **Type:** boolean
+- **Required:** no
+- **Default:** `true`
+- **Description:** Controls whether the activation job verifies that the frontmatter hash in the workflow matches its compiled `.lock.yml`.
+
+When `false`, disables the hash check step. This is needed when workflow files are managed outside the default repository context — for example, cross-repo org rulesets where the `.md` source and the compiled `.lock.yml` live in different repositories.
+
+```yaml
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  stale-check: false
+```
+
 ---
 
 ## 3. Permissions (`permissions:`)
@@ -801,6 +820,29 @@ environment: production
 environment:
   name: production
   url: "https://app.example.com"
+```
+
+### `run-install-scripts` {#run-install-scripts}
+
+- **Type:** boolean
+- **Required:** no
+- **Default:** `false`
+- **Description:** Allow npm pre/post install scripts to execute during package installation.
+
+By default, gh-aw adds `--ignore-scripts` to all generated `npm install` commands to prevent supply chain attacks via malicious install hooks. Setting this to `true` disables that protection globally for all runtimes that generate `npm install` commands.
+
+```yaml
+run-install-scripts: true
+```
+
+**⚠️ Security notice:** Emits a supply chain security warning at compile time. In `strict` mode, this is a compile error rather than a warning.
+
+**Per-runtime scope:** To limit the opt-out to a specific runtime rather than all runtimes, use:
+
+```yaml
+runtimes:
+  node:
+    run-install-scripts: true
 ```
 
 ---
@@ -1541,6 +1583,33 @@ safe-outputs:
 ---
 
 ## 8. Steps & Post-Steps
+
+### `pre-steps` {#pre-steps}
+
+- **Type:** object | array
+- **Required:** no
+- **Default:** none
+- **Description:** Custom workflow steps that run at the **very beginning** of the agent job, before the repository is checked out.
+
+```yaml
+pre-steps:
+  - name: Mint app token
+    id: app-token
+    uses: actions/create-github-app-token@v2
+    with:
+      app-id: ${{ vars.APP_ID }}
+      private-key: ${{ secrets.APP_KEY }}
+```
+
+**Use cases:**
+- **Token minting** that must happen before checkout (avoids masked-value cross-job boundary issues when the token is used in `checkout.github-token`)
+- Environment preparation that must precede repository access
+
+**Step outputs** are available via `${{ steps.<id>.outputs.<name> }}` and can be referenced in `checkout.github-token` and other pre-checkout fields.
+
+Same security restrictions apply as for `steps:` — runs outside the firewall sandbox with standard GitHub Actions security but no network egress controls.
+
+- **Cross-references:** `production-gotchas.md` — post-steps feature; see also `steps` and `post-steps`
 
 ### `steps`
 

--- a/skills/aw-author/references/frontmatter-schema.md
+++ b/skills/aw-author/references/frontmatter-schema.md
@@ -505,7 +505,7 @@ if: github.event.action == 'labeled' && contains(github.event.issue.labels.*.nam
 - **Type:** boolean
 - **Required:** no
 - **Default:** `true`
-- **Description:** Controls whether the activation job verifies that the frontmatter hash in the workflow matches its compiled `.lock.yml`.
+- **Description:** Sub-field of `on:`. Controls whether the activation job verifies that the frontmatter hash in the workflow matches its compiled `.lock.yml`.
 
 When `false`, disables the hash check step. This is needed when workflow files are managed outside the default repository context — for example, cross-repo org rulesets where the `.md` source and the compiled `.lock.yml` live in different repositories.
 
@@ -1582,7 +1582,7 @@ safe-outputs:
 
 ---
 
-## 8. Steps & Post-Steps
+## 8. Pre-Steps, Steps & Post-Steps
 
 ### `pre-steps` {#pre-steps}
 

--- a/skills/aw-author/references/tools-reference.md
+++ b/skills/aw-author/references/tools-reference.md
@@ -307,6 +307,8 @@ tools:
 | `scope` | string | `workflow` | `workflow` or `repo` |
 | `allowed-extensions` | array | `[".json", ".jsonl", ".txt", ".md", ".csv"]` | Allowed file types |
 
+**Pre-agent working-tree sanitization:** Before the agent job starts, `cache-memory` automatically scans the restored cache for planted executables and disallowed file types. Any neutralized files are logged as warnings in the workflow output. This protects against cache-poisoning attacks where a malicious actor could insert executable files or disallowed content into the cache between workflow runs.
+
 ### Repo Memory (`repo-memory:`)
 
 ```yaml

--- a/skills/gh-aw-report/knowledge-base.md
+++ b/skills/gh-aw-report/knowledge-base.md
@@ -105,4 +105,34 @@ US/EU data residency (2026-04-13). FedRAMP Moderate for US gov. `copilot --remot
 Workflow reruns capped at 50 (2026-04-10). OIDC for Dependabot/code scanning. Code scanning→Issues linking. Async SBOM exports.
 
 ---
+
+## [2026-04-16] Daily Intelligence Update
+
+### 2026-04-16 -- feature -- gh-aw v0.68.3 New Frontmatter Fields
+- **`pre-steps:`** — Runs custom steps at job start, **before checkout**. Use for token minting or pre-checkout setup. Outputs accessible via `${{ steps.<id>.outputs.<name> }}` for use in `checkout.github-token` to avoid masked-value cross-job boundary issues. Same security restrictions as `steps:`.
+- **`run-install-scripts:`** — Boolean (default: `false`). Allows npm pre/post install scripts. Default adds `--ignore-scripts` to all npm install commands (supply chain protection). Setting `true` disables globally; per-runtime scope via `runtimes.node.run-install-scripts`. Compile-time warning (strict mode: error).
+- **`on.stale-check:`** — Boolean nested under `on:`, default `true`. When `false`, disables the frontmatter hash check in the activation job. Required for cross-repo org ruleset deployments.
+- Source: PR #26607 in github/gh-aw ("Sync github-agentic-workflows.md with v0.68.3")
+
+### 2026-04-16 -- security -- gh-aw Security Fixes
+- **Steganographic injection**: PR #26596 strips markdown link title text to close injection channel
+- **XPIA @mentions**: PR #26589 sanitizes @mentions in `create_issue` body
+- **cache-memory sanitization**: PR #26587 adds pre-agent working-tree sanitization (neutralizes planted executables/disallowed files)
+- **Lock file integrity schema v4**: PR #26594 extends integrity check to detect post-compilation YAML tampering
+
+### 2026-04-16 -- version -- GitHub MCP Server v0.33.0/v0.33.1
+- **v0.33.0** (2026-04-14): Granular PRs/issues toolsets, `resolve_review_thread` tool, `list_commits` path/since/until params, configurable server name/title via translation strings, OSS HTTP logging adapter
+- **v0.33.1** (2026-04-14): Hotfix release
+
+### 2026-04-16 -- feature -- Claude Code Remote Tasks
+- **Remote Tasks** (launched March 20, 2026): Define GitHub repo + prompt + schedule → Claude runs autonomously on Anthropic cloud infrastructure. Supports cron scheduling.
+- **Remote Sessions**: Start task, close laptop, session continues on Anthropic infrastructure
+- **Open-sourced**: Agent layer at `anthropics/claude-code`
+- **v2.1.76** (March 14, 2026): Enhanced MCP elicitation support, improved tool discovery
+
+### 2026-04-16 -- feature -- Copilot Cloud Agent Per-Org Control
+- **Copilot cloud agent per-org control** (April 15, 2026): Can now be enabled for selected organizations via AI Controls page → "Agent" → "Copilot Cloud Agent"
+- **REST API version 2026-03-10**: Available with breaking changes to the REST API
+
+---
 <!-- Append new entries above this line, newest first -->

--- a/skills/gh-aw-report/references/gh-aw-architecture.md
+++ b/skills/gh-aw-report/references/gh-aw-architecture.md
@@ -85,9 +85,12 @@ Stable architectural facts about the GitHub Agentic Workflows ecosystem. Used by
 - **MCP Gateway:** Centralized access management for MCP servers (v0.1.9 as of 2026-04-14)
 
 ### Claude Code
-- Anthropic's CLI agentic coding tool
-- Integrates with GitHub via MCP servers
-- Can run gh-aw workflows locally for testing
+- Anthropic's CLI agentic coding tool, integrates with GitHub via MCP servers
+- Can serve as the AI engine in gh-aw workflows (alternative to Copilot CLI)
+- **Open-sourced** (2026): Agent layer at `anthropics/claude-code`
+- **Remote Tasks** (launched March 20, 2026): Define a GitHub repo + prompt + cron schedule → Claude runs autonomously on Anthropic's cloud infrastructure; cron scheduling supported
+- **Remote Sessions**: Start a task locally, close laptop; session continues on Anthropic infrastructure
+- Directly comparable to gh-aw scheduled workflows for Claude-engine use cases — a native Anthropic alternative that does not require GitHub Actions
 
 ## Ecosystem Integrations
 


### PR DESCRIPTION
## Summary

Automated reference file updates from daily intelligence sweep (2026-04-16).

## Gaps Addressed

- Closes #25 — Add `pre-steps:` field to frontmatter-schema.md (v0.68.3)
- Closes #26 — Add `run-install-scripts:` field to frontmatter-schema.md (v0.68.3)
- Closes #27 — Add `on.stale-check:` sub-field to frontmatter-schema.md (v0.68.3)
- Closes #28 — Document cache-memory working-tree sanitization in tools-reference.md
- Closes #29 — Add Claude Code Remote Tasks section to gh-aw-architecture.md

## Intelligence Report

https://github.com/zircote/github-agentic-workflows/discussions/24

## Changes

```
 .claude/skills/gh-aw-report/knowledge-base.md      | 30 ++++++++++
 .../gh-aw-report/references/gh-aw-architecture.md  | 11 +++-
 skills/aw-author/references/frontmatter-schema.md  | 69 ++++++++++++++++++++++
 skills/aw-author/references/tools-reference.md     |  2 +
 4 files changed, 111 insertions(+), 1 deletion(-)
```

---
_Automated by /aw-daily_