### PR TITLE
docs(references): daily intelligence update 2026-04-17 (#36)

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -5,6 +5,11 @@
       "version": "v9",
       "sha": "373c709c69115d41ff229c7e5df9f8788daa9553"
     },
+    "github/gh-aw-actions/setup-cli@v0.68.3": {
+      "repo": "github/gh-aw-actions/setup-cli",
+      "version": "v0.68.3",
+      "sha": "ba90f2186d7ad780ec640f364005fa24e797b360"
+    },
     "github/gh-aw-actions/setup@v0.68.3": {
       "repo": "github/gh-aw-actions/setup",
       "version": "v0.68.3",

--- a/outputs/gh-aw-reports/2026-04-17.md
+++ b/outputs/gh-aw-reports/2026-04-17.md
@@ -1,0 +1,113 @@
+# gh-aw Ecosystem Intelligence Report — 2026-04-17
+
+## Executive Summary
+
+Active day across all toolchains. gh-aw CLI holds at v0.68.3 (released 2026-04-14) — no new release today. Biggest movement: GitHub Copilot CLI hit v1.0.31 after 8 rapid releases since April 13, with v1.0.29 notably adding Claude Opus 4.7 support and making remote MCP server `type` field optional (defaults to `http`). Claude Code reached v2.1.112 with Claude Opus 4.7 `xhigh` effort mode, a 1-hour prompt cache TTL opt-in, and PreCompact hook support. The April 8 GitHub Copilot VS Code release formalized Autopilot mode (public preview) and nested subagents. One confirmed reference file gap: the `frontmatter-schema.md` models table still lists `gemini-pro` without a deprecation notice (deprecated 2026-03-26) and does not reflect Opus 4.7 availability.
+
+---
+
+## 1. gh-aw Core
+
+- **Current CLI version**: v0.68.3 (released 2026-04-14) — no new release since yesterday
+- **Last release highlights** (already captured 2026-04-16): `pre-steps:`, `run-install-scripts:`, `on.stale-check:` frontmatter fields; multiple security fixes for steganographic injection, XPIA @mentions, cache-memory sanitization, lock file integrity schema v4
+- **gh-aw-mcpg**: GitHub MCP guard policy confirmed GA — `tools.github` repos/min-integrity guard policy out of experimental status. DIFC guards enforce secrecy and integrity labels per request at the MCP Gateway level
+- **DIFC integrity log filtering**: `gh aw logs --filtered-integrity` flag added to filter runs where DIFC integrity events were triggered (security investigation tooling)
+- **Repo activity**: High-volume automated workflow runs on github/gh-aw itself; multiple refactoring PRs active
+
+---
+
+## 2. GitHub Copilot CLI — Rapid Iteration Week
+
+Latest: **v1.0.31** (2026-04-16). Eight releases since April 13:
+
+| Version | Date | Key Change |
+|---------|------|-----------|
+| v1.0.31 | 2026-04-16 | Prompt frame rendering fix (Windows/Ubuntu) |
+| v1.0.30 | 2026-04-16 | `/statusline` command (customize status bar items: directory, branch, effort, context, quota); plugin skills discovery fix |
+| v1.0.29 | 2026-04-16 | **Claude Opus 4.7 support**; remote MCP `type` field optional (defaults to `http`); `COPILOT_AGENT_SESSION_ID` env var; `--list-env` flag |
+| v1.0.28 | 2026-04-16 | Permission prompts fix for git submodules; Rewind picker simplified to arrow keys |
+| v1.0.27 | 2026-04-15 | `/ask` command (quick question without history); `copilot plugin marketplace update` |
+| v1.0.26 | 2026-04-14 | Escape key fix for ask_user/elicitation prompts; context compaction checkpoint boundary fix |
+| v1.0.25 | 2026-04-13 | **MCP server install from registry**; `/env` command (show loaded instructions, MCP servers, skills, agents, plugins); ACP clients can provide MCP servers on session start |
+| v1.0.24 | 2026-04-10 | `preToolUse` hooks respect `modifiedArgs`/`updatedInput`/`additionalContext`; custom agent model accepts display names (e.g., "Claude Sonnet 4.5") |
+| v1.0.23 | 2026-04-10 | `--mode`, `--autopilot`, `--plan` flags for starting in specific agent mode |
+
+**Breaking / behavior change**: Remote MCP server configs in Copilot CLI can now omit the `type` field — it defaults to `http`. Existing configs with explicit `type: http` continue to work.
+
+---
+
+## 3. GitHub Copilot Agent Mode / VS Code (April 8, 2026 Release)
+
+Source: [GitHub Changelog 2026-04-08](https://github.blog/changelog/2026-04-08-github-copilot-in-visual-studio-code-march-releases/)
+
+- **Autopilot mode** (public preview): Agents approve their own tool calls, automatically retry on errors, work autonomously until task completion without per-step permission prompts. Available on paid Copilot plans (Pro, Business, Enterprise); not available on free tier.
+- **Nested subagents**: Main Copilot agent can spawn child agents for subtasks, collecting results. Enabled via `chat.subagents.allowInvocationsFromSubagents` setting.
+- **Integrated browser debugging**: Set breakpoints, inspect variables without leaving VS Code
+- **Multimedia support**: Attach screenshots and videos to chat; agents can return visual recordings
+- **Faster codebase search**: `#codebase` tool uses purely semantic searches against a single auto-managed index
+- **Configurable thinking effort**: Adjustable for Claude Sonnet 4.6 and GPT-5.4 reasoning models
+- **MCP server cross-tool sync**: MCP servers configured in VS Code now work across Copilot CLI and Claude agent sessions
+- **Weekly stable releases**: VS Code transitioned to weekly stable cadence (covering v1.111–v1.115)
+- **Cloud agent expansion**: Copilot cloud agent (formerly coding agent) can now work on a branch without creating one, giving more flexibility over branch workflows
+
+---
+
+## 4. Claude Code — v2.1.112 (2026-04-16)
+
+Recent releases (April 13–16) relevant to gh-aw integration:
+
+| Version | Date | Key Change |
+|---------|------|-----------|
+| v2.1.112 | 2026-04-16 | Fix: `claude-opus-4-7` temporarily unavailable in auto mode |
+| v2.1.111 | 2026-04-16 | **Claude Opus 4.7 xhigh effort** (`/effort` interactive slider); Auto mode for Max subscribers with Opus 4.7 |
+| v2.1.110 | 2026-04-15 | `/tui` command (fullscreen flicker-free rendering); push notification tool; `autoScrollEnabled` config |
+| v2.1.108 | 2026-04-14 | **`ENABLE_PROMPT_CACHING_1H`** env var (1-hour cache TTL opt-in for API key, Bedrock, Vertex, Foundry); recap feature (`/recap`); model can discover/invoke background models |
+| v2.1.105 | 2026-04-13 | `EnterWorktree` `path` param (switch to existing worktree); **PreCompact hook** (can block compaction with exit 2 or `{decision:block}`); background monitors via `monitors` manifest key; `/proactive` alias for `/loop` |
+| v2.1.101 | 2026-04-10 | `/team-onboarding` command; OS CA cert store trust by default (enterprise TLS proxies); `/ultraplan` auto-creates cloud environment |
+
+**Claude Opus 4.7**: Available in Claude Code v2.1.111+ and Copilot CLI v1.0.29+. `xhigh` effort level sits between `high` and `max`.
+
+---
+
+## 5. GitHub Actions — Early April 2026
+
+Source: [GitHub Changelog 2026-04-02](https://github.blog/changelog/2026-04-02-github-actions-early-april-2026-updates/)
+
+- **Service containers**: New `entrypoint` and `command` override fields — allows customizing container startup without modifying the image
+- **OIDC custom properties**: New security feature for OIDC token customization
+- **Azure private networking VNET failover** (public preview): Configure a secondary Azure subnet (optionally different region) for GitHub Actions hosted runners. Triggered manually via UI/API or automatically by GitHub during regional outages
+
+**Also from March 2026 (not previously captured):**
+- **IANA timezone on cron schedules**: Add `timezone` field alongside cron expression instead of being locked to UTC
+- **Environments without auto-deployment**: Use `deployment: false` key on environment to access it without creating a deployment record
+
+---
+
+## 6. GitHub MCP Server
+
+- **v0.33.0 / v0.33.1** (2026-04-14): Already captured in previous report
+- **Native Streamable HTTP**: New `http` command in the server binary brings Streamable HTTP support into the main repository (previously only at api.githubcopilot.com/mcp)
+- **Insiders Mode**: Opt-in experimental features — first experiment is MCP Apps
+- **MCP remote server retry**: MCP remote server connections automatically retry on transient network failures
+
+---
+
+## 7. Reference File Gaps Identified
+
+| File | Gap | Priority |
+|------|-----|----------|
+| `frontmatter-schema.md` | `gemini-pro` model listed without deprecation notice (deprecated 2026-03-26) | High |
+| `frontmatter-schema.md` | Models table doesn't reflect Claude Opus 4.7 availability via Copilot CLI v1.0.29+ | Medium |
+| `frontmatter-schema.md` | IANA timezone support for Actions cron not referenced | Low |
+
+---
+
+## Sources
+
+- [GitHub Copilot CLI Releases](https://github.com/github/copilot-cli/releases)
+- [Claude Code Releases](https://github.com/anthropics/claude-code/releases)
+- [GitHub Changelog 2026-04-08 (VS Code March Releases)](https://github.blog/changelog/2026-04-08-github-copilot-in-visual-studio-code-march-releases/)
+- [GitHub Changelog 2026-04-02 (Actions Early April)](https://github.blog/changelog/2026-04-02-github-actions-early-april-2026-updates/)
+- [gh-aw Releases](https://github.com/github/gh-aw/releases)
+- [GitHub MCP Server](https://github.com/github/github-mcp-server)
+- [gh-aw MCP Gateway](https://github.com/github/gh-aw-mcpg)

--- a/skills/aw-author/references/frontmatter-schema.md
+++ b/skills/aw-author/references/frontmatter-schema.md
@@ -633,12 +633,14 @@ The `model:` sub-field accepts these values when using the `copilot` engine:
 
 | Model Value | Engine | Description |
 |-------------|--------|-------------|
-| `claude-opus` | Opus 4.6 | Highest-capability Anthropic model |
+| `claude-opus` | Opus 4.7 (CLI ≥ v1.0.29) / Opus 4.6 (older) | Highest-capability Anthropic model |
 | `claude-sonnet` | Sonnet 4.6 | Balanced speed and capability |
 | `gpt-5-codex` | GPT-5.3-Codex | OpenAI code-specialized model |
-| `gemini-pro` | Gemini 3 Pro | Google multimodal model |
+| ~~`gemini-pro`~~ | ~~Gemini 3 Pro~~ | **Deprecated 2026-03-26** — use `gemini-ultra` |
 
 Model availability depends on Copilot subscription tier and organization policy. The `claude` engine ID uses Claude models directly via Anthropic API (with `ANTHROPIC_API_KEY`), bypassing the Copilot model selector.
+
+> **Claude Opus 4.7**: Available in Copilot CLI v1.0.29+. The `claude-opus` model value now resolves to Opus 4.7 on compatible CLI versions. The `xhigh` thinking effort level is available for Opus 4.7 in Claude Code v2.1.111+ but is not a frontmatter field.
 
 ### Engine Sub-Fields
 

--- a/skills/gh-aw-report/knowledge-base.md
+++ b/skills/gh-aw-report/knowledge-base.md
@@ -135,4 +135,26 @@ Workflow reruns capped at 50 (2026-04-10). OIDC for Dependabot/code scanning. Co
 - **REST API version 2026-03-10**: Available with breaking changes to the REST API
 
 ---
+
+## [2026-04-17] Daily Intelligence Update
+
+### 2026-04-17 -- version -- GitHub Copilot CLI v1.0.31
+Latest (2026-04-16). Eight releases since April 13. Key: v1.0.29 adds Claude Opus 4.7 support, remote MCP server `type` field optional (defaults to `http`), `COPILOT_AGENT_SESSION_ID` env var. v1.0.25 adds MCP server install from registry, `/env` command showing loaded environment. v1.0.23 adds `--mode`/`--autopilot`/`--plan` flags.
+
+### 2026-04-17 -- version -- Claude Code v2.1.112
+Latest (2026-04-16). v2.1.111: Claude Opus 4.7 `xhigh` effort level, interactive `/effort` slider, Auto mode for Max subscribers. v2.1.108: `ENABLE_PROMPT_CACHING_1H` env var (1-hour cache TTL). v2.1.105: PreCompact hook (block compaction with exit code 2), background monitors via `monitors` manifest key, `EnterWorktree` `path` param. v2.1.101: OS CA cert store trust by default.
+
+### 2026-04-17 -- feature -- Copilot Autopilot Mode + Nested Subagents (April 8, 2026)
+**Autopilot mode** (public preview): Agents approve own tool calls, auto-retry, work autonomously to completion. Available Pro/Business/Enterprise, not free. **Nested subagents**: Main agent spawns child agents via `chat.subagents.allowInvocationsFromSubagents`. Configurable thinking effort for Claude Sonnet 4.6 and GPT-5.4. MCP servers in VS Code now sync across Copilot CLI and Claude agent sessions. Weekly stable releases (v1.111–v1.115).
+
+### 2026-04-17 -- feature -- GitHub Actions IANA Timezone + Environment Deployment Control
+**IANA timezone for cron**: Add `timezone` field alongside cron expression. **Environments without deployment**: Use `deployment: false` to access environment without creating a deployment record. **Early April**: Service container `entrypoint`/`command` overrides; Azure VNET failover for hosted runners (public preview).
+
+### 2026-04-17 -- security -- GitHub MCP Guard Policy GA
+`tools.github` repos/min-integrity guard policy out of experimental. DIFC (Decentralized Information Flow Control) guards enforce secrecy/integrity labels per request at MCP Gateway. `gh aw logs --filtered-integrity` flag for filtering runs with DIFC integrity events. MCP remote server connections auto-retry on transient network failures.
+
+### 2026-04-17 -- deprecation -- gemini-pro model deprecated (reference file gap)
+`gemini-pro` (Gemini 3 Pro) deprecated 2026-03-26 across Copilot CLI model selector. `frontmatter-schema.md` models table still lists it without deprecation notice — gap confirmed, fix in today's PR.
+
+---
 <!-- Append new entries above this line, newest first -->


### PR DESCRIPTION
## Summary

- **Daily report**: Copilot CLI v1.0.31 (8 rapid releases Apr 13–16), Claude Code v2.1.112 with Opus 4.7 `xhigh` effort, Autopilot mode + nested subagents (Apr 8 VS Code release), GitHub Actions IANA timezone + VNET failover
- **Knowledge base**: Updated with today's findings (Copilot CLI/Claude Code versions, Autopilot mode, MCP guard policy GA, Actions changes)
- **Reference fix**: `frontmatter-schema.md` — marked `gemini-pro` deprecated (2026-03-26), updated `claude-opus` description to reflect Opus 4.7 on Copilot CLI ≥ v1.0.29
- **Lock file**: actions-lock.json updated with `setup-cli@v0.68.3` SHA pin from compile run

## Quality Gates

- `gh aw compile`: ✅ 0 errors, 0 warnings
- `gh aw validate`: ✅ 0 errors, 0 warnings

## Discussion

Posted to Project News: https://github.com/zircote/github-agentic-workflows/discussions/36